### PR TITLE
Migrate to Swift 4

### DIFF
--- a/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
+++ b/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
@@ -369,7 +369,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -390,7 +389,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bloo7.persistentstoremigrationkit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -411,7 +409,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bloo7.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -428,7 +425,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bloo7.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;

--- a/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
+++ b/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
@@ -189,11 +189,11 @@
 				TargetAttributes = {
 					EDA89C281B8DEE7F00E9B761 = {
 						CreatedOnToolsVersion = 6.4;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0930;
 					};
 					EDA89C331B8DEE7F00E9B761 = {
 						CreatedOnToolsVersion = 6.4;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0930;
 					};
 				};
 			};
@@ -369,7 +369,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -389,7 +390,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bloo7.persistentstoremigrationkit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -409,7 +411,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bloo7.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -425,7 +428,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bloo7.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/PersistentStoreMigrationKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PersistentStoreMigrationKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/PersistentStoreMigrationKit/MigrationOperation.swift
+++ b/PersistentStoreMigrationKit/MigrationOperation.swift
@@ -49,7 +49,7 @@ public final class MigrationOperation: Operation {
 		case cancelled
 	}
 	/// The current state of the migration operation.
-	private(set) public dynamic var state = State.ready
+	@objc private(set) public dynamic var state = State.ready
 	
 	private func cancel(with error: Error) {
 		self.error = error

--- a/PersistentStoreMigrationKit/MigrationOperation.swift
+++ b/PersistentStoreMigrationKit/MigrationOperation.swift
@@ -11,23 +11,23 @@ import CoreData
 
 /// A `MigrationOperation` instance encapsulates the progressive migration from one `NSManagedObjectModel` to another with an arbitrary number of intermediate models.
 /// This is a companion to and implemented on top of the `MigrationPlan` class.
-public final class MigrationOperation: Operation {
+@objc public final class MigrationOperation: Operation {
 	/// Identifies the persistent store to migrate from.
-	public var sourceURL: URL!
+	@objc public var sourceURL: URL!
 	/// A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
-	public var sourceStoreType: String!
+	@objc public var sourceStoreType: String!
 	/// Identifies the persistent store to migrate to. May be identical to `sourceURL`.
-	public var destinationURL: URL!
+	@objc public var destinationURL: URL!
 	/// A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
-	public var destinationStoreType: String!
+	@objc public var destinationStoreType: String!
 	/// The model to migrate to.
-	public var destinationModel: NSManagedObjectModel!
+	@objc public var destinationModel: NSManagedObjectModel!
 	/// A list of bundles to search for the source model and intermediate models.
-	public var bundles: [Bundle]!
+	@objc public var bundles: [Bundle]!
 	/// The overall progress of the migration operation.
-	public let progress: Progress
+	@objc public let progress: Progress
 	/// Any error that may have occured during the execution of the migration operation.
-	public private(set) var error: Error?
+	@objc public private(set) var error: Error?
 	
 	/// Initializes a migration operation.
 	/// 
@@ -97,7 +97,7 @@ public final class MigrationOperation: Operation {
 		state = .finished
 	}
 	
-	class func keyPathsForValuesAffectingIsReady() -> Set<String> {
+	@objc class func keyPathsForValuesAffectingIsReady() -> Set<String> {
 		return ["state"]
 	}
 	
@@ -105,7 +105,7 @@ public final class MigrationOperation: Operation {
 		return state == .ready
 	}
 	
-	class func keyPathsForValuesAffectingIsExecuting() -> Set<String> {
+	@objc class func keyPathsForValuesAffectingIsExecuting() -> Set<String> {
 		return ["state"]
 	}
 	
@@ -113,7 +113,7 @@ public final class MigrationOperation: Operation {
 		return state == .executing
 	}
 	
-	class func keyPathsForValuesAffectingIsFinished() -> Set<String> {
+	@objc class func keyPathsForValuesAffectingIsFinished() -> Set<String> {
 		return ["state"]
 	}
 	
@@ -121,7 +121,7 @@ public final class MigrationOperation: Operation {
 		return state == .finished
 	}
 	
-	class func keyPathsForValuesAffectingIsCancelled() -> Set<String> {
+	@objc class func keyPathsForValuesAffectingIsCancelled() -> Set<String> {
 		return ["state"]
 	}
 	

--- a/PersistentStoreMigrationKit/MigrationPlan.swift
+++ b/PersistentStoreMigrationKit/MigrationPlan.swift
@@ -10,12 +10,12 @@ import Foundation
 import CoreData
 
 /// A `MigrationPlan` instance encapsulates the progressive migration from one `NSManagedObjectModel` to another with an arbitrary number of intermediate models.
-public final class MigrationPlan: NSObject {
+@objc public final class MigrationPlan: NSObject {
 	private var steps = [MigrationStep]()
 	/// The number of steps in the plan. Zero, if the plan is empty.
-	public var stepCount: Int { return steps.count }
+	@objc public var stepCount: Int { return steps.count }
 	/// Indicates whether executing the plan will do nothing.
-	public var isEmpty: Bool { return stepCount == 0 }
+	@objc public var isEmpty: Bool { return stepCount == 0 }
 	
 	private static func modelsInBundles(_ bundles: [Bundle]) -> [NSManagedObjectModel] {
 		var models = [NSManagedObjectModel]()
@@ -54,7 +54,7 @@ public final class MigrationPlan: NSObject {
 	///   - storeMetadata: The metadata of an existing persistent store.
 	///   - destinationModel: The model to migrate to.
 	///   - bundles: A list of bundles to search for the source model and intermediate models.
-	public init(storeMetadata: [String: Any], destinationModel: NSManagedObjectModel, bundles: [Bundle]) throws {
+	@objc public init(storeMetadata: [String: Any], destinationModel: NSManagedObjectModel, bundles: [Bundle]) throws {
 		precondition(!bundles.isEmpty, "Bundles must be non-empty.")
 		let _ = Progress(totalUnitCount: -1)
 		if destinationModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: storeMetadata) {
@@ -114,7 +114,7 @@ public final class MigrationPlan: NSObject {
 	///   - sourceStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
 	///   - destinationURL: Identifies the persistent store to migrate to. May be identical to `sourceURL`.
 	///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
-	public func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
+	@objc public func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
 		guard !isEmpty else { return }
 
 		// 10% setup, 80% actual migration steps, 10% cleanup.


### PR DESCRIPTION
Naively migrates to Swift 4.

This still uses Swift 2 conventions in many places, leaving lots of things still to be modernised.