### PR TITLE
Modernise Syntax

### DIFF
--- a/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
+++ b/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5B9AF29020A756C60065D972 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9AF28F20A756C60065D972 /* Error.swift */; };
 		ED27A2C51B8F45D9005FAFCB /* ModelV2ToModelV3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = EDA89C511B8DF11400E9B761 /* ModelV2ToModelV3.xcmappingmodel */; };
 		ED27A2C61B8F46B9005FAFCB /* ModelV1ToModelV2.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = EDA89C4E1B8DF0B500E9B761 /* ModelV1ToModelV2.xcmappingmodel */; };
 		ED27A2C71B8F46BC005FAFCB /* TestModelV2.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = EDA89C571B8DF15B00E9B761 /* TestModelV2.xcdatamodel */; };
@@ -31,6 +32,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5B9AF28F20A756C60065D972 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		ED69308E1B8E306700F9493D /* MigrationPlan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationPlan.swift; sourceTree = "<group>"; };
 		ED6930921B8E4E0300F9493D /* MigrationStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationStep.swift; sourceTree = "<group>"; };
 		EDA89C291B8DEE7F00E9B761 /* PersistentStoreMigrationKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PersistentStoreMigrationKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -91,6 +93,7 @@
 				EDA89C451B8DEEA800E9B761 /* MigrationOperation.swift */,
 				ED69308E1B8E306700F9493D /* MigrationPlan.swift */,
 				ED6930921B8E4E0300F9493D /* MigrationStep.swift */,
+				5B9AF28F20A756C60065D972 /* Error.swift */,
 				EDA89C2C1B8DEE7F00E9B761 /* Supporting Files */,
 			);
 			path = PersistentStoreMigrationKit;
@@ -237,6 +240,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B9AF29020A756C60065D972 /* Error.swift in Sources */,
 				ED6930931B8E4E0300F9493D /* MigrationStep.swift in Sources */,
 				EDA89C461B8DEEA800E9B761 /* MigrationOperation.swift in Sources */,
 				ED69308F1B8E306700F9493D /* MigrationPlan.swift in Sources */,

--- a/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
+++ b/PersistentStoreMigrationKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5B9AF29020A756C60065D972 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9AF28F20A756C60065D972 /* Error.swift */; };
+		5B9AF29220A757830065D972 /* NSManagedObjectModel+Aggregation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9AF29120A757830065D972 /* NSManagedObjectModel+Aggregation.swift */; };
 		ED27A2C51B8F45D9005FAFCB /* ModelV2ToModelV3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = EDA89C511B8DF11400E9B761 /* ModelV2ToModelV3.xcmappingmodel */; };
 		ED27A2C61B8F46B9005FAFCB /* ModelV1ToModelV2.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = EDA89C4E1B8DF0B500E9B761 /* ModelV1ToModelV2.xcmappingmodel */; };
 		ED27A2C71B8F46BC005FAFCB /* TestModelV2.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = EDA89C571B8DF15B00E9B761 /* TestModelV2.xcdatamodel */; };
@@ -33,6 +34,7 @@
 
 /* Begin PBXFileReference section */
 		5B9AF28F20A756C60065D972 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		5B9AF29120A757830065D972 /* NSManagedObjectModel+Aggregation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectModel+Aggregation.swift"; sourceTree = "<group>"; };
 		ED69308E1B8E306700F9493D /* MigrationPlan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationPlan.swift; sourceTree = "<group>"; };
 		ED6930921B8E4E0300F9493D /* MigrationStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationStep.swift; sourceTree = "<group>"; };
 		EDA89C291B8DEE7F00E9B761 /* PersistentStoreMigrationKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PersistentStoreMigrationKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -94,6 +96,7 @@
 				ED69308E1B8E306700F9493D /* MigrationPlan.swift */,
 				ED6930921B8E4E0300F9493D /* MigrationStep.swift */,
 				5B9AF28F20A756C60065D972 /* Error.swift */,
+				5B9AF29120A757830065D972 /* NSManagedObjectModel+Aggregation.swift */,
 				EDA89C2C1B8DEE7F00E9B761 /* Supporting Files */,
 			);
 			path = PersistentStoreMigrationKit;
@@ -240,6 +243,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B9AF29220A757830065D972 /* NSManagedObjectModel+Aggregation.swift in Sources */,
 				5B9AF29020A756C60065D972 /* Error.swift in Sources */,
 				ED6930931B8E4E0300F9493D /* MigrationStep.swift in Sources */,
 				EDA89C461B8DEEA800E9B761 /* MigrationOperation.swift in Sources */,

--- a/PersistentStoreMigrationKit/Error.swift
+++ b/PersistentStoreMigrationKit/Error.swift
@@ -1,0 +1,18 @@
+//
+//  Error.swift
+//  PersistentStoreMigrationKit
+//
+//  Created by Georg Brückmann on 12.05.18.
+//  Copyright © 2018 Georg C. Brückmann. All rights reserved.
+//
+
+import Foundation
+
+public enum Error: Swift.Error {
+    /// Model version hashes are missing from store metadata.
+    case missingStoreModelVersionHashes
+    /// Could not find the source model for a migration step.
+    case couldNotFindSourceModel
+    /// Could not find a destination and mapping model for a migration step.
+    case couldNotInferMappingSteps
+}

--- a/PersistentStoreMigrationKit/MigrationOperation.swift
+++ b/PersistentStoreMigrationKit/MigrationOperation.swift
@@ -87,7 +87,7 @@ import CoreData
         // Execute migration plan.
         progress.becomeCurrent(withPendingUnitCount: 90)
         do {
-            try migrationPlan.executeForStoreAtURL(sourceURL, type: sourceStoreType, destinationURL: destinationURL, storeType: destinationStoreType)
+            try migrationPlan.executeForStore(at: sourceURL, type: sourceStoreType, destinationURL: destinationURL, storeType: destinationStoreType)
         } catch {
             cancel(with: error)
             return

--- a/PersistentStoreMigrationKit/MigrationOperation.swift
+++ b/PersistentStoreMigrationKit/MigrationOperation.swift
@@ -12,120 +12,120 @@ import CoreData
 /// A `MigrationOperation` instance encapsulates the progressive migration from one `NSManagedObjectModel` to another with an arbitrary number of intermediate models.
 /// This is a companion to and implemented on top of the `MigrationPlan` class.
 @objc public final class MigrationOperation: Operation {
-	/// Identifies the persistent store to migrate from.
-	@objc public var sourceURL: URL!
-	/// A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
-	@objc public var sourceStoreType: String!
-	/// Identifies the persistent store to migrate to. May be identical to `sourceURL`.
-	@objc public var destinationURL: URL!
-	/// A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
-	@objc public var destinationStoreType: String!
-	/// The model to migrate to.
-	@objc public var destinationModel: NSManagedObjectModel!
-	/// A list of bundles to search for the source model and intermediate models.
-	@objc public var bundles: [Bundle]!
-	/// The overall progress of the migration operation.
-	@objc public let progress: Progress
-	/// Any error that may have occured during the execution of the migration operation.
-	@objc public private(set) var error: Error?
-	
-	/// Initializes a migration operation.
-	/// 
-	/// Inserts an `NSProgress` instance into the current progress tree.
-	override public required init() {
-		progress = Progress(totalUnitCount: 100)
-		super.init()
-	}
-	
-	/// Defines possible migration operation states.
-	@objc public enum State: Int {
-		/// The migration operation is ready to execute.
-		case ready
-		/// The migration operation is executing.
-		case executing
-		/// The migration operation has finished executing.
-		case finished
-		/// The migration operation has been cancelled.
-		case cancelled
-	}
-	/// The current state of the migration operation.
-	@objc private(set) public dynamic var state = State.ready
-	
-	private func cancel(with error: Error) {
-		self.error = error
-		state = .cancelled
-	}
-	
-	// MARK: NSOperation
-	public override func start() {
-		precondition(sourceURL != nil, "Missing source URL.")
-		precondition(sourceStoreType != nil, "Missing source store type.")
-		precondition(destinationURL != nil, "Missing destination URL.")
-		precondition(destinationStoreType != nil, "Missing desetination store type.")
-		precondition(destinationModel != nil, "Missing destination model.")
-		precondition(bundles != nil, "Missing bundles.")
-		state = .executing
-		
-		let existingStoreMetadata: [String: AnyObject]
-		do {
-			existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: sourceStoreType, at: sourceURL) as [String : AnyObject]
-		} catch {
+    /// Identifies the persistent store to migrate from.
+    @objc public var sourceURL: URL!
+    /// A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
+    @objc public var sourceStoreType: String!
+    /// Identifies the persistent store to migrate to. May be identical to `sourceURL`.
+    @objc public var destinationURL: URL!
+    /// A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
+    @objc public var destinationStoreType: String!
+    /// The model to migrate to.
+    @objc public var destinationModel: NSManagedObjectModel!
+    /// A list of bundles to search for the source model and intermediate models.
+    @objc public var bundles: [Bundle]!
+    /// The overall progress of the migration operation.
+    @objc public let progress: Progress
+    /// Any error that may have occured during the execution of the migration operation.
+    @objc public private(set) var error: Error?
+
+    /// Initializes a migration operation.
+    ///
+    /// Inserts an `NSProgress` instance into the current progress tree.
+    override public required init() {
+        progress = Progress(totalUnitCount: 100)
+        super.init()
+    }
+
+    /// Defines possible migration operation states.
+    @objc public enum State: Int {
+        /// The migration operation is ready to execute.
+        case ready
+        /// The migration operation is executing.
+        case executing
+        /// The migration operation has finished executing.
+        case finished
+        /// The migration operation has been cancelled.
+        case cancelled
+    }
+    /// The current state of the migration operation.
+    @objc private(set) public dynamic var state = State.ready
+
+    private func cancel(with error: Error) {
+        self.error = error
+        state = .cancelled
+    }
+
+    // MARK: NSOperation
+    public override func start() {
+        precondition(sourceURL != nil, "Missing source URL.")
+        precondition(sourceStoreType != nil, "Missing source store type.")
+        precondition(destinationURL != nil, "Missing destination URL.")
+        precondition(destinationStoreType != nil, "Missing desetination store type.")
+        precondition(destinationModel != nil, "Missing destination model.")
+        precondition(bundles != nil, "Missing bundles.")
+        state = .executing
+
+        let existingStoreMetadata: [String: AnyObject]
+        do {
+            existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: sourceStoreType, at: sourceURL) as [String : AnyObject]
+        } catch {
             cancel(with: error)
-			return
-		}
-		
-		// Devise migration plan.
-		let migrationPlan: MigrationPlan
-		do {
-			migrationPlan = try MigrationPlan(storeMetadata: existingStoreMetadata, destinationModel: destinationModel, bundles: bundles)
-		} catch {
-			cancel(with: error)
-			return
-		}
-		progress.completedUnitCount += 10
-		
-		// Execute migration plan.
-		progress.becomeCurrent(withPendingUnitCount: 90)
-		do {
-			try migrationPlan.executeForStoreAtURL(sourceURL, type: sourceStoreType, destinationURL: destinationURL, storeType: destinationStoreType)
-		} catch {
-			cancel(with: error)
-			return
-		}
-		progress.resignCurrent()
-		
-		state = .finished
-	}
-	
-	@objc class func keyPathsForValuesAffectingIsReady() -> Set<String> {
-		return ["state"]
-	}
-	
-	override public var isReady: Bool {
-		return state == .ready
-	}
-	
-	@objc class func keyPathsForValuesAffectingIsExecuting() -> Set<String> {
-		return ["state"]
-	}
-	
-	override public var isExecuting: Bool {
-		return state == .executing
-	}
-	
-	@objc class func keyPathsForValuesAffectingIsFinished() -> Set<String> {
-		return ["state"]
-	}
-	
-	override public var isFinished: Bool {
-		return state == .finished
-	}
-	
-	@objc class func keyPathsForValuesAffectingIsCancelled() -> Set<String> {
-		return ["state"]
-	}
-	
-	override public var isCancelled: Bool {
-		return state == .cancelled
-	}
+            return
+        }
+
+        // Devise migration plan.
+        let migrationPlan: MigrationPlan
+        do {
+            migrationPlan = try MigrationPlan(storeMetadata: existingStoreMetadata, destinationModel: destinationModel, bundles: bundles)
+        } catch {
+            cancel(with: error)
+            return
+        }
+        progress.completedUnitCount += 10
+
+        // Execute migration plan.
+        progress.becomeCurrent(withPendingUnitCount: 90)
+        do {
+            try migrationPlan.executeForStoreAtURL(sourceURL, type: sourceStoreType, destinationURL: destinationURL, storeType: destinationStoreType)
+        } catch {
+            cancel(with: error)
+            return
+        }
+        progress.resignCurrent()
+
+        state = .finished
+    }
+
+    @objc class func keyPathsForValuesAffectingIsReady() -> Set<String> {
+        return ["state"]
+    }
+
+    override public var isReady: Bool {
+        return state == .ready
+    }
+
+    @objc class func keyPathsForValuesAffectingIsExecuting() -> Set<String> {
+        return ["state"]
+    }
+
+    override public var isExecuting: Bool {
+        return state == .executing
+    }
+
+    @objc class func keyPathsForValuesAffectingIsFinished() -> Set<String> {
+        return ["state"]
+    }
+
+    override public var isFinished: Bool {
+        return state == .finished
+    }
+
+    @objc class func keyPathsForValuesAffectingIsCancelled() -> Set<String> {
+        return ["state"]
+    }
+
+    override public var isCancelled: Bool {
+        return state == .cancelled
+    }
 }

--- a/PersistentStoreMigrationKit/MigrationOperation.swift
+++ b/PersistentStoreMigrationKit/MigrationOperation.swift
@@ -27,7 +27,7 @@ import CoreData
     /// The overall progress of the migration operation.
     @objc public let progress: Progress
     /// Any error that may have occured during the execution of the migration operation.
-    @objc public private(set) var error: Error?
+    @objc public private(set) var error: Swift.Error?
 
     /// Initializes a migration operation.
     ///
@@ -51,7 +51,7 @@ import CoreData
     /// The current state of the migration operation.
     @objc private(set) public dynamic var state = State.ready
 
-    private func cancel(with error: Error) {
+    private func cancel(with error: Swift.Error) {
         self.error = error
         state = .cancelled
     }

--- a/PersistentStoreMigrationKit/MigrationPlan.swift
+++ b/PersistentStoreMigrationKit/MigrationPlan.swift
@@ -54,7 +54,7 @@ import CoreData
     ///   - sourceStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
     ///   - destinationURL: Identifies the persistent store to migrate to. May be identical to `sourceURL`.
     ///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
-    @objc public func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
+    @objc public func executeForStore(at sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
         guard !isEmpty else { return }
 
         // 10% setup, 80% actual migration steps, 10% cleanup.
@@ -77,7 +77,7 @@ import CoreData
             do {
                 steppingProgress.becomeCurrent(withPendingUnitCount: 1)
                 defer { steppingProgress.resignCurrent() }
-                try step.executeForStoreAtURL(latestStoreURL, type: latestStoreType, destinationURL: stepDestinationURL, storeType: destinationStoreType)
+                try step.executeForStore(at: latestStoreURL, type: latestStoreType, destinationURL: stepDestinationURL, storeType: destinationStoreType)
             } catch {
                 let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
                 throw error

--- a/PersistentStoreMigrationKit/MigrationPlan.swift
+++ b/PersistentStoreMigrationKit/MigrationPlan.swift
@@ -13,9 +13,9 @@ import CoreData
 @objc public final class MigrationPlan: NSObject {
     private let steps: [MigrationStep]
     /// The number of steps in the plan. Zero, if the plan is empty.
-    @objc public var stepCount: Int { return steps.count }
+    @objc public var numberOfSteps: Int { return steps.count }
     /// Indicates whether executing the plan will do nothing.
-    @objc public var isEmpty: Bool { return stepCount == 0 }
+    @objc public var isEmpty: Bool { return numberOfSteps == 0 }
     
     /// Devises a migration plan based on the metadata of an existing store, a destination managed object model and a list of bundles to search for intermediate models.
     /// 
@@ -72,7 +72,7 @@ import CoreData
         var latestStoreURL = sourceURL
         var latestStoreType = sourceStoreType
         for (stepIndex, step) in steps.enumerated() {
-            let stepDestinationURL = storeReplacementDirectory.appendingPathComponent("Migrated Store (Step \(stepIndex + 1) of \(stepCount))", isDirectory: false)
+            let stepDestinationURL = storeReplacementDirectory.appendingPathComponent("Migrated Store (Step \(stepIndex + 1) of \(numberOfSteps))", isDirectory: false)
             var stepError: Swift.Error?
             do {
                 steppingProgress.becomeCurrent(withPendingUnitCount: 1)

--- a/PersistentStoreMigrationKit/MigrationPlan.swift
+++ b/PersistentStoreMigrationKit/MigrationPlan.swift
@@ -11,160 +11,160 @@ import CoreData
 
 /// A `MigrationPlan` instance encapsulates the progressive migration from one `NSManagedObjectModel` to another with an arbitrary number of intermediate models.
 @objc public final class MigrationPlan: NSObject {
-	private var steps = [MigrationStep]()
-	/// The number of steps in the plan. Zero, if the plan is empty.
-	@objc public var stepCount: Int { return steps.count }
-	/// Indicates whether executing the plan will do nothing.
-	@objc public var isEmpty: Bool { return stepCount == 0 }
-	
-	private static func modelsInBundles(_ bundles: [Bundle]) -> [NSManagedObjectModel] {
-		var models = [NSManagedObjectModel]()
-		for bundle in bundles {
-			if let modelURLs = bundle.urls(forResourcesWithExtension: "mom", subdirectory: nil) {
-				for modelURL in modelURLs {
-					if let model = NSManagedObjectModel(contentsOf: modelURL) {
-						models.append(model)
-					}
-				}
-			}
-			if let modelURLs = bundle.urls(forResourcesWithExtension: "momd", subdirectory: nil) {
-				for modelBundleURL in modelURLs {
-					if let modelBundle = Bundle(url: modelBundleURL),
-						let modelURLs = modelBundle.urls(forResourcesWithExtension: "mom", subdirectory: nil)
-					{
-						for modelURL in modelURLs {
-							if let model = NSManagedObjectModel(contentsOf: modelURL) {
-								models.append(model)
-							}
-						}
-					}
-				}
-			}
-		}
-		return models
-	}
-	
-	/// Devises a migration plan based on the metadata of an existing store, a destination managed object model and a list of bundles to search for intermediate models.
-	/// 
-	/// If no migration is necessary (i.e. the existing store's metadata is compatible with the destination model), the initialized plan will be empty.
-	/// 
-	/// - Throws: Throws an error if a migration plan cannot be devised.
-	/// 
-	/// - Parameters:
-	///   - storeMetadata: The metadata of an existing persistent store.
-	///   - destinationModel: The model to migrate to.
-	///   - bundles: A list of bundles to search for the source model and intermediate models.
-	@objc public init(storeMetadata: [String: Any], destinationModel: NSManagedObjectModel, bundles: [Bundle]) throws {
-		precondition(!bundles.isEmpty, "Bundles must be non-empty.")
-		let _ = Progress(totalUnitCount: -1)
-		if destinationModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: storeMetadata) {
-			super.init()
-			return
-		}
-		guard let storeModelVersionHashes = storeMetadata[NSStoreModelVersionHashesKey] as? [String: Any] else {
-			super.init()
-			throw Error.missingStoreModelVersionHashes
-		}
-		var latestModelVersionHashes = storeModelVersionHashes
-		let models = type(of: self).modelsInBundles(bundles)
-		while !(latestModelVersionHashes as NSDictionary).isEqual(to: destinationModel.entityVersionHashesByName) {
-			var stepSourceModel: NSManagedObjectModel!
-			for model in models {
-				if (model.entityVersionHashesByName as NSDictionary).isEqual(to: latestModelVersionHashes) {
-					stepSourceModel = model
-				}
-			}
-			if stepSourceModel == nil {
-				super.init()
-				throw Error.couldNotFindSourceModel
-			}
-			var stepDestinationModel: NSManagedObjectModel!
-			var stepMappingModel: NSMappingModel!
-			for model in models {
-				if let mappingModel = NSMappingModel(from: bundles, forSourceModel: stepSourceModel, destinationModel: model) {
-					stepDestinationModel = model
-					stepMappingModel = mappingModel
-					break
-				}
-			}
-			if stepDestinationModel == nil ||
-				stepMappingModel == nil
-			{
-				super.init()
-				throw Error.couldNotInferMappingSteps
-			}
-			latestModelVersionHashes = stepDestinationModel.entityVersionHashesByName as [String : AnyObject]
-			let migrationStep = MigrationStep(sourceModel: stepSourceModel, destinationModel: stepDestinationModel, mappingModel: stepMappingModel)
-			steps.append(migrationStep)
-		}
-		if steps.isEmpty {
-			super.init()
-			throw Error.couldNotInferMappingSteps
-		}
-		super.init()
-	}
-	
-	/// Performs the migration from the persistent store identified by `sourceURL` to `destinationModel`, saving the result in the persistent store identified by `destinationURL`.
-	/// The migration is guaranteed to be atomic.
-	/// 
-	/// Inserts an `NSProgress` instance into the current progress tree.
-	/// 
-	/// - Parameters:
-	///   - sourceURL: Identifies the persistent store to migrate from.
-	///   - sourceStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
-	///   - destinationURL: Identifies the persistent store to migrate to. May be identical to `sourceURL`.
-	///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
-	@objc public func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
-		guard !isEmpty else { return }
+    private var steps = [MigrationStep]()
+    /// The number of steps in the plan. Zero, if the plan is empty.
+    @objc public var stepCount: Int { return steps.count }
+    /// Indicates whether executing the plan will do nothing.
+    @objc public var isEmpty: Bool { return stepCount == 0 }
+    
+    private static func modelsInBundles(_ bundles: [Bundle]) -> [NSManagedObjectModel] {
+        var models = [NSManagedObjectModel]()
+        for bundle in bundles {
+            if let modelURLs = bundle.urls(forResourcesWithExtension: "mom", subdirectory: nil) {
+                for modelURL in modelURLs {
+                    if let model = NSManagedObjectModel(contentsOf: modelURL) {
+                        models.append(model)
+                    }
+                }
+            }
+            if let modelURLs = bundle.urls(forResourcesWithExtension: "momd", subdirectory: nil) {
+                for modelBundleURL in modelURLs {
+                    if let modelBundle = Bundle(url: modelBundleURL),
+                        let modelURLs = modelBundle.urls(forResourcesWithExtension: "mom", subdirectory: nil)
+                    {
+                        for modelURL in modelURLs {
+                            if let model = NSManagedObjectModel(contentsOf: modelURL) {
+                                models.append(model)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return models
+    }
+    
+    /// Devises a migration plan based on the metadata of an existing store, a destination managed object model and a list of bundles to search for intermediate models.
+    /// 
+    /// If no migration is necessary (i.e. the existing store's metadata is compatible with the destination model), the initialized plan will be empty.
+    /// 
+    /// - Throws: Throws an error if a migration plan cannot be devised.
+    /// 
+    /// - Parameters:
+    ///   - storeMetadata: The metadata of an existing persistent store.
+    ///   - destinationModel: The model to migrate to.
+    ///   - bundles: A list of bundles to search for the source model and intermediate models.
+    @objc public init(storeMetadata: [String: Any], destinationModel: NSManagedObjectModel, bundles: [Bundle]) throws {
+        precondition(!bundles.isEmpty, "Bundles must be non-empty.")
+        let _ = Progress(totalUnitCount: -1)
+        if destinationModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: storeMetadata) {
+            super.init()
+            return
+        }
+        guard let storeModelVersionHashes = storeMetadata[NSStoreModelVersionHashesKey] as? [String: Any] else {
+            super.init()
+            throw Error.missingStoreModelVersionHashes
+        }
+        var latestModelVersionHashes = storeModelVersionHashes
+        let models = type(of: self).modelsInBundles(bundles)
+        while !(latestModelVersionHashes as NSDictionary).isEqual(to: destinationModel.entityVersionHashesByName) {
+            var stepSourceModel: NSManagedObjectModel!
+            for model in models {
+                if (model.entityVersionHashesByName as NSDictionary).isEqual(to: latestModelVersionHashes) {
+                    stepSourceModel = model
+                }
+            }
+            if stepSourceModel == nil {
+                super.init()
+                throw Error.couldNotFindSourceModel
+            }
+            var stepDestinationModel: NSManagedObjectModel!
+            var stepMappingModel: NSMappingModel!
+            for model in models {
+                if let mappingModel = NSMappingModel(from: bundles, forSourceModel: stepSourceModel, destinationModel: model) {
+                    stepDestinationModel = model
+                    stepMappingModel = mappingModel
+                    break
+                }
+            }
+            if stepDestinationModel == nil ||
+                stepMappingModel == nil
+            {
+                super.init()
+                throw Error.couldNotInferMappingSteps
+            }
+            latestModelVersionHashes = stepDestinationModel.entityVersionHashesByName as [String : AnyObject]
+            let migrationStep = MigrationStep(sourceModel: stepSourceModel, destinationModel: stepDestinationModel, mappingModel: stepMappingModel)
+            steps.append(migrationStep)
+        }
+        if steps.isEmpty {
+            super.init()
+            throw Error.couldNotInferMappingSteps
+        }
+        super.init()
+    }
+    
+    /// Performs the migration from the persistent store identified by `sourceURL` to `destinationModel`, saving the result in the persistent store identified by `destinationURL`.
+    /// The migration is guaranteed to be atomic.
+    /// 
+    /// Inserts an `NSProgress` instance into the current progress tree.
+    /// 
+    /// - Parameters:
+    ///   - sourceURL: Identifies the persistent store to migrate from.
+    ///   - sourceStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
+    ///   - destinationURL: Identifies the persistent store to migrate to. May be identical to `sourceURL`.
+    ///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
+    @objc public func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
+        guard !isEmpty else { return }
 
-		// 10% setup, 80% actual migration steps, 10% cleanup.
-		let overallProgress = Progress(totalUnitCount: 100)
-		
-		// Setup
-		let storeReplacementDirectory: URL!
+        // 10% setup, 80% actual migration steps, 10% cleanup.
+        let overallProgress = Progress(totalUnitCount: 100)
+        
+        // Setup
+        let storeReplacementDirectory: URL!
         storeReplacementDirectory = try FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: destinationURL, create: true)
-		overallProgress.completedUnitCount += 10
-		
-		// Execute migration steps.
-		overallProgress.becomeCurrent(withPendingUnitCount: 80)
-		let steppingProgress = Progress(totalUnitCount: Int64(steps.count))
-		overallProgress.resignCurrent()
-		var latestStoreURL = sourceURL
-		var latestStoreType = sourceStoreType
-		for (stepIndex, step) in steps.enumerated() {
-			let stepDestinationURL = storeReplacementDirectory.appendingPathComponent("Migrated Store (Step \(stepIndex + 1) of \(stepCount))", isDirectory: false)
-			var stepError: Error?
-			do {
-				steppingProgress.becomeCurrent(withPendingUnitCount: 1)
-				defer { steppingProgress.resignCurrent() }
-				try step.executeForStoreAtURL(latestStoreURL, type: latestStoreType, destinationURL: stepDestinationURL, storeType: destinationStoreType)
-			} catch {
-				let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
-				throw error
-			}
-			latestStoreURL = stepDestinationURL
-			latestStoreType = destinationStoreType
-		}
-		
-		// Cleanup
-		do {
-			try FileManager.default.replaceItem(at: destinationURL, withItemAt: latestStoreURL, backupItemName: nil, options: [], resultingItemURL: nil)
-		} catch {
-			let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
-			throw error
-		}
-		let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
-		overallProgress.completedUnitCount += 10
-	}
+        overallProgress.completedUnitCount += 10
+        
+        // Execute migration steps.
+        overallProgress.becomeCurrent(withPendingUnitCount: 80)
+        let steppingProgress = Progress(totalUnitCount: Int64(steps.count))
+        overallProgress.resignCurrent()
+        var latestStoreURL = sourceURL
+        var latestStoreType = sourceStoreType
+        for (stepIndex, step) in steps.enumerated() {
+            let stepDestinationURL = storeReplacementDirectory.appendingPathComponent("Migrated Store (Step \(stepIndex + 1) of \(stepCount))", isDirectory: false)
+            var stepError: Error?
+            do {
+                steppingProgress.becomeCurrent(withPendingUnitCount: 1)
+                defer { steppingProgress.resignCurrent() }
+                try step.executeForStoreAtURL(latestStoreURL, type: latestStoreType, destinationURL: stepDestinationURL, storeType: destinationStoreType)
+            } catch {
+                let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
+                throw error
+            }
+            latestStoreURL = stepDestinationURL
+            latestStoreType = destinationStoreType
+        }
+        
+        // Cleanup
+        do {
+            try FileManager.default.replaceItem(at: destinationURL, withItemAt: latestStoreURL, backupItemName: nil, options: [], resultingItemURL: nil)
+        } catch {
+            let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
+            throw error
+        }
+        let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
+        overallProgress.completedUnitCount += 10
+    }
 }
 
 public extension MigrationPlan {
-	public enum Error: Swift.Error {
-		/// Model version hashes are missing from store metadata.
-		case missingStoreModelVersionHashes
-		/// Could not find the source model for a migration step.
-		case couldNotFindSourceModel
-		/// Could not find a destination and mapping model for a migration step.
-		case couldNotInferMappingSteps
-	}
+    public enum Error: Swift.Error {
+        /// Model version hashes are missing from store metadata.
+        case missingStoreModelVersionHashes
+        /// Could not find the source model for a migration step.
+        case couldNotFindSourceModel
+        /// Could not find a destination and mapping model for a migration step.
+        case couldNotInferMappingSteps
+    }
 }

--- a/PersistentStoreMigrationKit/MigrationPlan.swift
+++ b/PersistentStoreMigrationKit/MigrationPlan.swift
@@ -60,7 +60,8 @@ import CoreData
     @objc public init(storeMetadata: [String: Any], destinationModel: NSManagedObjectModel, bundles: [Bundle]) throws {
         precondition(!bundles.isEmpty, "Bundles must be non-empty.")
         let _ = Progress(totalUnitCount: -1)
-        if destinationModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: storeMetadata) {
+        guard !destinationModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: storeMetadata) else {
+            // No work to be done.
             super.init()
             return
         }

--- a/PersistentStoreMigrationKit/MigrationPlan.swift
+++ b/PersistentStoreMigrationKit/MigrationPlan.swift
@@ -65,7 +65,6 @@ import CoreData
             return
         }
         guard let storeModelVersionHashes = storeMetadata[NSStoreModelVersionHashesKey] as? [String: Any] else {
-            super.init()
             throw Error.missingStoreModelVersionHashes
         }
         var latestModelVersionHashes = storeModelVersionHashes
@@ -78,7 +77,6 @@ import CoreData
                 }
             }
             if stepSourceModel == nil {
-                super.init()
                 throw Error.couldNotFindSourceModel
             }
             var stepDestinationModel: NSManagedObjectModel!
@@ -93,7 +91,6 @@ import CoreData
             if stepDestinationModel == nil ||
                 stepMappingModel == nil
             {
-                super.init()
                 throw Error.couldNotInferMappingSteps
             }
             latestModelVersionHashes = stepDestinationModel.entityVersionHashesByName as [String : AnyObject]
@@ -101,7 +98,6 @@ import CoreData
             steps.append(migrationStep)
         }
         if steps.isEmpty {
-            super.init()
             throw Error.couldNotInferMappingSteps
         }
         super.init()

--- a/PersistentStoreMigrationKit/MigrationPlan.swift
+++ b/PersistentStoreMigrationKit/MigrationPlan.swift
@@ -133,7 +133,7 @@ import CoreData
         var latestStoreType = sourceStoreType
         for (stepIndex, step) in steps.enumerated() {
             let stepDestinationURL = storeReplacementDirectory.appendingPathComponent("Migrated Store (Step \(stepIndex + 1) of \(stepCount))", isDirectory: false)
-            var stepError: Error?
+            var stepError: Swift.Error?
             do {
                 steppingProgress.becomeCurrent(withPendingUnitCount: 1)
                 defer { steppingProgress.resignCurrent() }
@@ -155,16 +155,5 @@ import CoreData
         }
         let _ = try? FileManager.default.removeItem(at: storeReplacementDirectory)
         overallProgress.completedUnitCount += 10
-    }
-}
-
-public extension MigrationPlan {
-    public enum Error: Swift.Error {
-        /// Model version hashes are missing from store metadata.
-        case missingStoreModelVersionHashes
-        /// Could not find the source model for a migration step.
-        case couldNotFindSourceModel
-        /// Could not find a destination and mapping model for a migration step.
-        case couldNotInferMappingSteps
     }
 }

--- a/PersistentStoreMigrationKit/MigrationStep.swift
+++ b/PersistentStoreMigrationKit/MigrationStep.swift
@@ -57,3 +57,51 @@ final class MigrationStep: NSObject {
         try migrationManager.migrateStore(from: sourceURL, sourceType: sourceStoreType, options: nil, with: mappingModel, toDestinationURL: destinationURL, destinationType: destinationStoreType, destinationOptions: nil)
     }
 }
+
+extension MigrationStep {
+
+    /// Figures out which steps need to be performed to migrate an existing to a destination model.
+    ///
+    /// - parameter storeMetadata: The metadata of an existing persistent store.
+    /// - parameter destinationModel: The model to migrate to.
+    /// - parameter bundles: A list of bundles to search for the source model and intermediate models.
+    ///
+    /// - Throws: Throws an error, if the necessary steps cannot be determined.
+    static func stepsForMigratingExistingStore(withMetadata storeMetadata: [String: Any], to destinationModel: NSManagedObjectModel, searchBundles bundles: [Bundle]) throws -> [MigrationStep] {
+        var steps: [MigrationStep] = []
+        guard let storeModelVersionHashes = storeMetadata[NSStoreModelVersionHashesKey] as? [String: Any] else {
+            throw Error.missingStoreModelVersionHashes
+        }
+        var latestModelVersionHashes = storeModelVersionHashes
+        let models = NSManagedObjectModel.models(in: bundles)
+        while !(latestModelVersionHashes as NSDictionary).isEqual(to: destinationModel.entityVersionHashesByName) {
+            var stepSourceModel: NSManagedObjectModel!
+            for model in models {
+                if (model.entityVersionHashesByName as NSDictionary).isEqual(to: latestModelVersionHashes) {
+                    stepSourceModel = model
+                }
+            }
+            if stepSourceModel == nil {
+                throw Error.couldNotFindSourceModel
+            }
+            var stepDestinationModel: NSManagedObjectModel!
+            var stepMappingModel: NSMappingModel!
+            for model in models {
+                if let mappingModel = NSMappingModel(from: bundles, forSourceModel: stepSourceModel, destinationModel: model) {
+                    stepDestinationModel = model
+                    stepMappingModel = mappingModel
+                    break
+                }
+            }
+            if stepDestinationModel == nil ||
+                stepMappingModel == nil
+            {
+                throw Error.couldNotInferMappingSteps
+            }
+            latestModelVersionHashes = stepDestinationModel.entityVersionHashesByName as [String : AnyObject]
+            let migrationStep = MigrationStep(sourceModel: stepSourceModel, destinationModel: stepDestinationModel, mappingModel: stepMappingModel)
+            steps.append(migrationStep)
+        }
+        return steps
+    }
+}

--- a/PersistentStoreMigrationKit/MigrationStep.swift
+++ b/PersistentStoreMigrationKit/MigrationStep.swift
@@ -42,7 +42,7 @@ final class MigrationStep: NSObject {
     ///   - sourceStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
     ///   - destinationURL: Identifies the persistent store to migrate to. May be identical to `sourceURL`.
     ///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
-    func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
+    func executeForStore(at sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
         let progress = Progress(totalUnitCount: 100)
         self.progress = progress
         defer { self.progress = nil }

--- a/PersistentStoreMigrationKit/MigrationStep.swift
+++ b/PersistentStoreMigrationKit/MigrationStep.swift
@@ -12,61 +12,61 @@ import CoreData
 /// A `MigrationStep` instance encapsulates the migration from one `NSManagedObjectModel` to another without any intermediate models.
 /// Migration is performed via an `NSMigrationManager` using an `NSMappingModel`.
 final class MigrationStep: NSObject {
-	/// Specifies how to from `sourceModel` to `destinationModel`.
-	let mappingModel: NSMappingModel
-	/// The model to migrate from.
-	let sourceModel: NSManagedObjectModel
-	/// The model to migrate to.
-	let destinationModel: NSManagedObjectModel
-	
-	private var keyValueObservingContext = UUID().uuidString
-	
-	/// Initializes a migration step for a source model, destination model, and a mapping model.
-	/// 
-	/// - Parameters:
-	///   - sourceModel: The model to migrate from.
-	///   - destinationModel: The model to migrate to.
-	///   - mappingModel: Specifies how to from `sourceModel` to `destinationModel`.
-	init(sourceModel: NSManagedObjectModel, destinationModel: NSManagedObjectModel, mappingModel: NSMappingModel) {
-		self.sourceModel = sourceModel
-		self.destinationModel = destinationModel
-		self.mappingModel = mappingModel
-	}
-	
-	private var progress: Progress?
-	
-	/// Performs the migration from the persistent store identified by `sourceURL` and using `sourceModel` to `destinationModel`, saving the result in the persistent store identified by `destinationURL`.
-	/// 
-	/// Inserts an `NSProgress` instance into the current progress tree.
-	/// 
-	/// - Parameters:
-	///   - sourceURL: Identifies the persistent store to migrate from.
-	///   - sourceStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
-	///   - destinationURL: Identifies the persistent store to migrate to. May be identical to `sourceURL`.
-	///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
-	func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
-		progress = Progress(totalUnitCount: 100)
-		defer { progress = nil }
-		let migrationManager = NSMigrationManager(sourceModel: sourceModel, destinationModel: destinationModel)
-		migrationManager.addObserver(self, forKeyPath: "migrationProgress", options: .new, context: &keyValueObservingContext)
-		defer { migrationManager.removeObserver(self, forKeyPath: "migrationProgress", context: &keyValueObservingContext) }
-		try migrationManager.migrateStore(from: sourceURL, sourceType: sourceStoreType, options: nil, with: mappingModel, toDestinationURL: destinationURL, destinationType: destinationStoreType, destinationOptions: nil)
-	}
-	
-	// MARK: NSKeyValueObserving
-	override func observeValue(forKeyPath keyPath: String!, of object: Any!, change: [NSKeyValueChangeKey : Any]!, context: UnsafeMutableRawPointer?) {
-		if context != &keyValueObservingContext {
-			super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
-			return
-		}
-		if let _ = object as? NSMigrationManager {
-			switch keyPath {
-			case "migrationProgress":
-				let newMigrationProgress = (change[NSKeyValueChangeKey.newKey] as! NSNumber).floatValue
-				progress?.completedUnitCount = Int64(newMigrationProgress * 100)
-			default:
-				break
-			}
-		}
-	}
+    /// Specifies how to from `sourceModel` to `destinationModel`.
+    let mappingModel: NSMappingModel
+    /// The model to migrate from.
+    let sourceModel: NSManagedObjectModel
+    /// The model to migrate to.
+    let destinationModel: NSManagedObjectModel
+    
+    private var keyValueObservingContext = UUID().uuidString
+    
+    /// Initializes a migration step for a source model, destination model, and a mapping model.
+    /// 
+    /// - Parameters:
+    ///   - sourceModel: The model to migrate from.
+    ///   - destinationModel: The model to migrate to.
+    ///   - mappingModel: Specifies how to from `sourceModel` to `destinationModel`.
+    init(sourceModel: NSManagedObjectModel, destinationModel: NSManagedObjectModel, mappingModel: NSMappingModel) {
+        self.sourceModel = sourceModel
+        self.destinationModel = destinationModel
+        self.mappingModel = mappingModel
+    }
+    
+    private var progress: Progress?
+    
+    /// Performs the migration from the persistent store identified by `sourceURL` and using `sourceModel` to `destinationModel`, saving the result in the persistent store identified by `destinationURL`.
+    /// 
+    /// Inserts an `NSProgress` instance into the current progress tree.
+    /// 
+    /// - Parameters:
+    ///   - sourceURL: Identifies the persistent store to migrate from.
+    ///   - sourceStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the source store type.
+    ///   - destinationURL: Identifies the persistent store to migrate to. May be identical to `sourceURL`.
+    ///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
+    func executeForStoreAtURL(_ sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
+        progress = Progress(totalUnitCount: 100)
+        defer { progress = nil }
+        let migrationManager = NSMigrationManager(sourceModel: sourceModel, destinationModel: destinationModel)
+        migrationManager.addObserver(self, forKeyPath: "migrationProgress", options: .new, context: &keyValueObservingContext)
+        defer { migrationManager.removeObserver(self, forKeyPath: "migrationProgress", context: &keyValueObservingContext) }
+        try migrationManager.migrateStore(from: sourceURL, sourceType: sourceStoreType, options: nil, with: mappingModel, toDestinationURL: destinationURL, destinationType: destinationStoreType, destinationOptions: nil)
+    }
+    
+    // MARK: NSKeyValueObserving
+    override func observeValue(forKeyPath keyPath: String!, of object: Any!, change: [NSKeyValueChangeKey : Any]!, context: UnsafeMutableRawPointer?) {
+        if context != &keyValueObservingContext {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+            return
+        }
+        if let _ = object as? NSMigrationManager {
+            switch keyPath {
+            case "migrationProgress":
+                let newMigrationProgress = (change[NSKeyValueChangeKey.newKey] as! NSNumber).floatValue
+                progress?.completedUnitCount = Int64(newMigrationProgress * 100)
+            default:
+                break
+            }
+        }
+    }
 }

--- a/PersistentStoreMigrationKit/NSManagedObjectModel+Aggregation.swift
+++ b/PersistentStoreMigrationKit/NSManagedObjectModel+Aggregation.swift
@@ -1,0 +1,42 @@
+//
+//  NSManagedObjectModel+Aggregation.swift
+//  PersistentStoreMigrationKit
+//
+//  Created by Georg Brückmann on 12.05.18.
+//  Copyright © 2018 Georg C. Brückmann. All rights reserved.
+//
+
+import Foundation
+
+extension NSManagedObjectModel {
+
+    /// Aggregates all valid models in the given bundles.
+    ///
+    /// - Attention: Invalid model files will trigger assertion failures.
+    static func models(in bundles: [Bundle]) -> [NSManagedObjectModel] {
+        var modelURLs: [URL] = []
+        // Collect simple Core Data model URLs
+        modelURLs += bundles.flatMap { (bundle) in
+            return bundle.urls(forResourcesWithExtension: "mom", subdirectory: nil) ?? []
+        }
+        // Collect versioned Core Data model URLs
+        modelURLs += bundles.flatMap { (bundle) -> [URL] in
+            guard let modelBundleURLs = bundle.urls(forResourcesWithExtension: "momd", subdirectory: nil) else { return [] }
+            return modelBundleURLs.flatMap { (modelBundleURL) -> [URL] in
+                guard let modelBundle = Bundle(url: modelBundleURL) else {
+                    assertionFailure("\(modelBundleURL) is not a valid versioned Core Data model (bundle).")
+                    return []
+                }
+                return modelBundle.urls(forResourcesWithExtension: "mom", subdirectory: nil) ?? []
+            }
+        }
+        // Load models at all the above URLs
+        return modelURLs.compactMap { (modelURL) in
+            guard let model = NSManagedObjectModel(contentsOf: modelURL) else {
+                assertionFailure("\(modelURL) is not a valid Core Data model.")
+                return nil
+            }
+            return model
+        }
+    }
+}

--- a/PersistentStoreMigrationKitTests/PersistentStoreMigrationKitTests.swift
+++ b/PersistentStoreMigrationKitTests/PersistentStoreMigrationKitTests.swift
@@ -158,7 +158,7 @@ class PersistentStoreMigrationKitTests: XCTestCase {
             return
         }
         let expectedMigrationPlanStepCount = models.count - 1
-        XCTAssertEqual(migrationPlan.stepCount, expectedMigrationPlanStepCount, "Migration plan step count should be \(expectedMigrationPlanStepCount), but is \(migrationPlan.stepCount).")
+        XCTAssertEqual(migrationPlan.numberOfSteps, expectedMigrationPlanStepCount, "Migration plan step count should be \(expectedMigrationPlanStepCount), but is \(migrationPlan.numberOfSteps).")
         do {
             try migrationPlan.executeForStoreAtURL(storeURL, type: storeType, destinationURL: storeURL, storeType: storeType)
         } catch {

--- a/PersistentStoreMigrationKitTests/PersistentStoreMigrationKitTests.swift
+++ b/PersistentStoreMigrationKitTests/PersistentStoreMigrationKitTests.swift
@@ -13,220 +13,220 @@ import XCTest
 
 class PersistentStoreMigrationKitTests: XCTestCase {
     private var models: [NSManagedObjectModel] = []
-	private var workingDirectoryURL: URL!
-	private let storeType = NSSQLiteStoreType
-	private var testBundle: Bundle!
+    private var workingDirectoryURL: URL!
+    private let storeType = NSSQLiteStoreType
+    private var testBundle: Bundle!
     
     override func setUp() {
         super.setUp()
-		testBundle = Bundle(for: type(of: self))
-		
-		for versionNumber in 1...3 {
-			let modelURL: URL! = testBundle.url(forResource: "TestModelV\(versionNumber)", withExtension: "mom")
-			XCTAssertNotNil(modelURL, "Could not locate V\(versionNumber) test model.")
-			let model: NSManagedObjectModel! = NSManagedObjectModel(contentsOf: modelURL)
-			XCTAssertNotNil(model, "Could not load V\(versionNumber) test model.")
-			models.append(model)
-		}
-		
-		// Create working directory.
-		let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-		workingDirectoryURL = temporaryDirectoryURL.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
-		do {
-			try FileManager.default.createDirectory(at: workingDirectoryURL, withIntermediateDirectories: true, attributes: nil)
-		} catch {
-			XCTFail("Could not create working directory: \(error)")
-		}
+        testBundle = Bundle(for: type(of: self))
+        
+        for versionNumber in 1...3 {
+            let modelURL: URL! = testBundle.url(forResource: "TestModelV\(versionNumber)", withExtension: "mom")
+            XCTAssertNotNil(modelURL, "Could not locate V\(versionNumber) test model.")
+            let model: NSManagedObjectModel! = NSManagedObjectModel(contentsOf: modelURL)
+            XCTAssertNotNil(model, "Could not load V\(versionNumber) test model.")
+            models.append(model)
+        }
+        
+        // Create working directory.
+        let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        workingDirectoryURL = temporaryDirectoryURL.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
+        do {
+            try FileManager.default.createDirectory(at: workingDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            XCTFail("Could not create working directory: \(error)")
+        }
     }
     
     override func tearDown() {
-		if let workingDirectoryURL = workingDirectoryURL {
-			do {
-				try FileManager.default.removeItem(at: workingDirectoryURL)
-			} catch {
-				XCTFail("Could not remove working directory: \(error)")
-			}
-		}
+        if let workingDirectoryURL = workingDirectoryURL {
+            do {
+                try FileManager.default.removeItem(at: workingDirectoryURL)
+            } catch {
+                XCTFail("Could not remove working directory: \(error)")
+            }
+        }
         super.tearDown()
     }
-	
-	private func initializeStoreAtURL(_ storeURL: URL) throws {
-		let initialPersistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: models.first!)
-		try initialPersistentStoreCoordinator.addPersistentStore(ofType: storeType, configurationName: nil, at: storeURL, options: nil)
-	}
+    
+    private func initializeStoreAtURL(_ storeURL: URL) throws {
+        let initialPersistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: models.first!)
+        try initialPersistentStoreCoordinator.addPersistentStore(ofType: storeType, configurationName: nil, at: storeURL, options: nil)
+    }
     
     func testManualStoreMigration() {
-		let storeURL = workingDirectoryURL.appendingPathComponent("Manually Migrated Store", isDirectory: false)
-		do {
-			try initializeStoreAtURL(storeURL)
-		} catch {
-			XCTFail("Could not initialize persistent store: \(error)")
-			return
-		}
-		
-		for newerModel in models[models.indices.suffix(from: 1)] {
-			let existingStoreMetadata: [String: AnyObject]
-			do {
-				existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
-			} catch {
-				XCTFail("Could not retrieve store metadata: \(error)")
-				return
-			}
-			let existingStoreVersionHashes = existingStoreMetadata[NSStoreModelVersionHashesKey] as! [AnyHashable: Any]!
-			XCTAssertNotNil(existingStoreVersionHashes, "Could not retrieve version hashes from \(storeURL).")
-			var sourceModel: NSManagedObjectModel!
-			for model in models {
-				if (model.entityVersionHashesByName as NSDictionary).isEqual(to: existingStoreVersionHashes) {
-					sourceModel = model
-					break
-				}
-			}
-			XCTAssertNotNil(sourceModel, "Could not determine source model for store migration.")
-			print("Source model entity version hashes:")
-			for (entityName, versionHash) in existingStoreVersionHashes! {
-				print("\(entityName): \(versionHash)")
-			}
-			print("Target model entity version hashes:")
-			for (entityName, versionHash) in newerModel.entityVersionHashesByName {
-				print("\(entityName): \(versionHash)")
-			}
-			let mappingModel: NSMappingModel! = NSMappingModel(from: [testBundle], forSourceModel: sourceModel!, destinationModel: newerModel)
-			XCTAssertNotNil(mappingModel, "Could not find a model for mapping \(sourceModel) to \(newerModel).")
-			let migrationManager = NSMigrationManager(sourceModel: sourceModel, destinationModel: newerModel)
-			let storeReplacementDirectoryURL: URL
-			do {
-				storeReplacementDirectoryURL = try FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: storeURL, create: true)
-			} catch {
-				XCTFail("Could not create item replacement directory for migrating store: \(error)")
-				return
-			}
-			let temporaryStoreURL = storeReplacementDirectoryURL.appendingPathComponent(storeURL.lastPathComponent, isDirectory: false)
-			do {
-				try migrationManager.migrateStore(from: storeURL, sourceType: storeType, options: nil, with: mappingModel, toDestinationURL: temporaryStoreURL, destinationType: storeType, destinationOptions: nil)
-			} catch {
-				XCTFail("Could not migrate \(storeURL) from \(sourceModel) to \(newerModel): \(error)")
-				return
-			}
-			do {
+        let storeURL = workingDirectoryURL.appendingPathComponent("Manually Migrated Store", isDirectory: false)
+        do {
+            try initializeStoreAtURL(storeURL)
+        } catch {
+            XCTFail("Could not initialize persistent store: \(error)")
+            return
+        }
+        
+        for newerModel in models[models.indices.suffix(from: 1)] {
+            let existingStoreMetadata: [String: AnyObject]
+            do {
+                existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
+            } catch {
+                XCTFail("Could not retrieve store metadata: \(error)")
+                return
+            }
+            let existingStoreVersionHashes = existingStoreMetadata[NSStoreModelVersionHashesKey] as! [AnyHashable: Any]!
+            XCTAssertNotNil(existingStoreVersionHashes, "Could not retrieve version hashes from \(storeURL).")
+            var sourceModel: NSManagedObjectModel!
+            for model in models {
+                if (model.entityVersionHashesByName as NSDictionary).isEqual(to: existingStoreVersionHashes) {
+                    sourceModel = model
+                    break
+                }
+            }
+            XCTAssertNotNil(sourceModel, "Could not determine source model for store migration.")
+            print("Source model entity version hashes:")
+            for (entityName, versionHash) in existingStoreVersionHashes! {
+                print("\(entityName): \(versionHash)")
+            }
+            print("Target model entity version hashes:")
+            for (entityName, versionHash) in newerModel.entityVersionHashesByName {
+                print("\(entityName): \(versionHash)")
+            }
+            let mappingModel: NSMappingModel! = NSMappingModel(from: [testBundle], forSourceModel: sourceModel!, destinationModel: newerModel)
+            XCTAssertNotNil(mappingModel, "Could not find a model for mapping \(sourceModel) to \(newerModel).")
+            let migrationManager = NSMigrationManager(sourceModel: sourceModel, destinationModel: newerModel)
+            let storeReplacementDirectoryURL: URL
+            do {
+                storeReplacementDirectoryURL = try FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: storeURL, create: true)
+            } catch {
+                XCTFail("Could not create item replacement directory for migrating store: \(error)")
+                return
+            }
+            let temporaryStoreURL = storeReplacementDirectoryURL.appendingPathComponent(storeURL.lastPathComponent, isDirectory: false)
+            do {
+                try migrationManager.migrateStore(from: storeURL, sourceType: storeType, options: nil, with: mappingModel, toDestinationURL: temporaryStoreURL, destinationType: storeType, destinationOptions: nil)
+            } catch {
+                XCTFail("Could not migrate \(storeURL) from \(sourceModel) to \(newerModel): \(error)")
+                return
+            }
+            do {
                 try FileManager.default.replaceItem(at: storeURL, withItemAt: temporaryStoreURL, backupItemName: nil, options: [], resultingItemURL: nil)
-			} catch {
-				XCTFail("Could not replace \(storeURL) with migrated store \(temporaryStoreURL): \(error)")
-				return
-			}
-			do {
-				try FileManager.default.removeItem(at: storeReplacementDirectoryURL)
-			} catch {
-				XCTFail("Could not remove item replacmeent directory after migrating store: \(error)")
-				return
-			}
-		}
+            } catch {
+                XCTFail("Could not replace \(storeURL) with migrated store \(temporaryStoreURL): \(error)")
+                return
+            }
+            do {
+                try FileManager.default.removeItem(at: storeReplacementDirectoryURL)
+            } catch {
+                XCTFail("Could not remove item replacmeent directory after migrating store: \(error)")
+                return
+            }
+        }
     }
-	
-	func testAutomaticMigration() {
-		let storeURL = workingDirectoryURL.appendingPathComponent("Automatically Migrated Store", isDirectory: false)
-		do {
-			try initializeStoreAtURL(storeURL)
-		} catch {
-			XCTFail("Could not initialize persistent store: \(error)")
-			return
-		}
-		
-		let latestModel = models.last!
-		let existingStoreMetadata: [String: AnyObject]
-		do {
-			existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
-		} catch {
-			XCTFail("Could not retrieve store metadata: \(error)")
-			return
-		}
-		let existingStoreVersionHashes = existingStoreMetadata[NSStoreModelVersionHashesKey] as! [String: AnyObject]!
-		XCTAssertNotNil(existingStoreVersionHashes, "Could not retrieve version hashes from \(storeURL).")
-		let migrationPlan: MigrationPlan
-		do {
-			migrationPlan = try MigrationPlan(storeMetadata: existingStoreMetadata, destinationModel: latestModel, bundles: [testBundle])
-		} catch {
-			XCTFail("Could not devise migration plan for \(storeURL): \(error)")
-			return
-		}
-		let expectedMigrationPlanStepCount = models.count - 1
-		XCTAssertEqual(migrationPlan.stepCount, expectedMigrationPlanStepCount, "Migration plan step count should be \(expectedMigrationPlanStepCount), but is \(migrationPlan.stepCount).")
-		do {
-			try migrationPlan.executeForStoreAtURL(storeURL, type: storeType, destinationURL: storeURL, storeType: storeType)
-		} catch {
-			XCTFail("Could not execute migration plan for \(storeURL): \(error)")
-			return
-		}
-		let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: latestModel)
-		do {
-			let _ = try persistentStoreCoordinator.addPersistentStore(ofType: storeType, configurationName: nil, at: storeURL, options: nil)
-		} catch {
-			XCTFail("Could not load persistent store after migration: \(error)")
-			return
-		}
-	}
-	
-	func testMigrationOperation() {
-		let storeURL = workingDirectoryURL.appendingPathComponent("Automatically Migrated Store", isDirectory: false)
-		do {
-			try initializeStoreAtURL(storeURL)
-		} catch {
-			XCTFail("Could not initialize persistent store: \(error)")
-			return
-		}
-		
-		let latestModel = models.last!
-		let existingStoreMetadata: [String: AnyObject]
-		do {
-			existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
-		} catch {
-			XCTFail("Could not retrieve store metadata: \(error)")
-			return
-		}
-		let existingStoreVersionHashes = existingStoreMetadata[NSStoreModelVersionHashesKey] as! [String: AnyObject]!
-		XCTAssertNotNil(existingStoreVersionHashes, "Could not retrieve version hashes from \(storeURL).")
-		
-		let operationExpectation = expectation(description: "Migration operation succeeded")
-		let operationQueue = OperationQueue()
-		operationQueue.name = "Core Data Migration Test"
-		let migrationOperation = MigrationOperation()
-		migrationOperation.sourceURL = storeURL
-		migrationOperation.sourceStoreType = storeType
-		migrationOperation.destinationURL = storeURL
-		migrationOperation.destinationStoreType = storeType
-		migrationOperation.destinationModel = latestModel
-		migrationOperation.bundles = [testBundle]
-		migrationOperation.completionBlock = {
-			XCTAssertNil(migrationOperation.error, "Migration operation failed: \(migrationOperation.error!)")
-			operationExpectation.fulfill()
-		}
-		operationQueue.addOperation(migrationOperation)
-		waitForExpectations(timeout: 10) { error in
-			if error != nil {
-				return
-			}
-			let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: latestModel)
-			do {
-				try persistentStoreCoordinator.addPersistentStore(ofType: self.storeType, configurationName: nil, at: storeURL, options: nil)
-			} catch {
-				XCTFail("Could not load persistent store after migration: \(error)")
-				return
-			}
-		}
-	}
-	
-	func testMigrationFailure() {
-		let storeURL = workingDirectoryURL.appendingPathComponent("Store That Does Not Exist", isDirectory: false)
-		let latestModel = models.last!
-		let existingStoreMetadata: [String: AnyObject]
-		do {
-			existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
-			XCTFail("Retrieving store metadata for nonexistant store succeeded: \(existingStoreMetadata)")
-		} catch {
-			existingStoreMetadata = [:]
-		}
-		do {
-			let migrationPlan = try MigrationPlan(storeMetadata: existingStoreMetadata, destinationModel: latestModel, bundles: [testBundle])
-			XCTFail("Devising migration plan for nonexistant store succeeded: \(migrationPlan)")
-		} catch {}
-	}
+    
+    func testAutomaticMigration() {
+        let storeURL = workingDirectoryURL.appendingPathComponent("Automatically Migrated Store", isDirectory: false)
+        do {
+            try initializeStoreAtURL(storeURL)
+        } catch {
+            XCTFail("Could not initialize persistent store: \(error)")
+            return
+        }
+        
+        let latestModel = models.last!
+        let existingStoreMetadata: [String: AnyObject]
+        do {
+            existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
+        } catch {
+            XCTFail("Could not retrieve store metadata: \(error)")
+            return
+        }
+        let existingStoreVersionHashes = existingStoreMetadata[NSStoreModelVersionHashesKey] as! [String: AnyObject]!
+        XCTAssertNotNil(existingStoreVersionHashes, "Could not retrieve version hashes from \(storeURL).")
+        let migrationPlan: MigrationPlan
+        do {
+            migrationPlan = try MigrationPlan(storeMetadata: existingStoreMetadata, destinationModel: latestModel, bundles: [testBundle])
+        } catch {
+            XCTFail("Could not devise migration plan for \(storeURL): \(error)")
+            return
+        }
+        let expectedMigrationPlanStepCount = models.count - 1
+        XCTAssertEqual(migrationPlan.stepCount, expectedMigrationPlanStepCount, "Migration plan step count should be \(expectedMigrationPlanStepCount), but is \(migrationPlan.stepCount).")
+        do {
+            try migrationPlan.executeForStoreAtURL(storeURL, type: storeType, destinationURL: storeURL, storeType: storeType)
+        } catch {
+            XCTFail("Could not execute migration plan for \(storeURL): \(error)")
+            return
+        }
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: latestModel)
+        do {
+            let _ = try persistentStoreCoordinator.addPersistentStore(ofType: storeType, configurationName: nil, at: storeURL, options: nil)
+        } catch {
+            XCTFail("Could not load persistent store after migration: \(error)")
+            return
+        }
+    }
+    
+    func testMigrationOperation() {
+        let storeURL = workingDirectoryURL.appendingPathComponent("Automatically Migrated Store", isDirectory: false)
+        do {
+            try initializeStoreAtURL(storeURL)
+        } catch {
+            XCTFail("Could not initialize persistent store: \(error)")
+            return
+        }
+        
+        let latestModel = models.last!
+        let existingStoreMetadata: [String: AnyObject]
+        do {
+            existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
+        } catch {
+            XCTFail("Could not retrieve store metadata: \(error)")
+            return
+        }
+        let existingStoreVersionHashes = existingStoreMetadata[NSStoreModelVersionHashesKey] as! [String: AnyObject]!
+        XCTAssertNotNil(existingStoreVersionHashes, "Could not retrieve version hashes from \(storeURL).")
+        
+        let operationExpectation = expectation(description: "Migration operation succeeded")
+        let operationQueue = OperationQueue()
+        operationQueue.name = "Core Data Migration Test"
+        let migrationOperation = MigrationOperation()
+        migrationOperation.sourceURL = storeURL
+        migrationOperation.sourceStoreType = storeType
+        migrationOperation.destinationURL = storeURL
+        migrationOperation.destinationStoreType = storeType
+        migrationOperation.destinationModel = latestModel
+        migrationOperation.bundles = [testBundle]
+        migrationOperation.completionBlock = {
+            XCTAssertNil(migrationOperation.error, "Migration operation failed: \(migrationOperation.error!)")
+            operationExpectation.fulfill()
+        }
+        operationQueue.addOperation(migrationOperation)
+        waitForExpectations(timeout: 10) { error in
+            if error != nil {
+                return
+            }
+            let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: latestModel)
+            do {
+                try persistentStoreCoordinator.addPersistentStore(ofType: self.storeType, configurationName: nil, at: storeURL, options: nil)
+            } catch {
+                XCTFail("Could not load persistent store after migration: \(error)")
+                return
+            }
+        }
+    }
+    
+    func testMigrationFailure() {
+        let storeURL = workingDirectoryURL.appendingPathComponent("Store That Does Not Exist", isDirectory: false)
+        let latestModel = models.last!
+        let existingStoreMetadata: [String: AnyObject]
+        do {
+            existingStoreMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: storeURL) as [String : AnyObject]
+            XCTFail("Retrieving store metadata for nonexistant store succeeded: \(existingStoreMetadata)")
+        } catch {
+            existingStoreMetadata = [:]
+        }
+        do {
+            let migrationPlan = try MigrationPlan(storeMetadata: existingStoreMetadata, destinationModel: latestModel, bundles: [testBundle])
+            XCTFail("Devising migration plan for nonexistant store succeeded: \(migrationPlan)")
+        } catch {}
+    }
 }

--- a/PersistentStoreMigrationKitTests/PersistentStoreMigrationKitTests.swift
+++ b/PersistentStoreMigrationKitTests/PersistentStoreMigrationKitTests.swift
@@ -160,7 +160,7 @@ class PersistentStoreMigrationKitTests: XCTestCase {
         let expectedMigrationPlanStepCount = models.count - 1
         XCTAssertEqual(migrationPlan.numberOfSteps, expectedMigrationPlanStepCount, "Migration plan step count should be \(expectedMigrationPlanStepCount), but is \(migrationPlan.numberOfSteps).")
         do {
-            try migrationPlan.executeForStoreAtURL(storeURL, type: storeType, destinationURL: storeURL, storeType: storeType)
+            try migrationPlan.executeForStore(at: storeURL, type: storeType, destinationURL: storeURL, storeType: storeType)
         } catch {
             XCTFail("Could not execute migration plan for \(storeURL): \(error)")
             return


### PR DESCRIPTION
Subtly modernises the syntax by:

- using `guard` more where appropriate,
- using Swift 3 KVO,
- removing unnecessary calls to super initialisers, and
- renaming a few properties and methods to match current conventions.

Also unnests the `Error` type from `MigrationPlan` and moves helper methods to more appropriate places.

Closes #8.