### PR TITLE
Improve A → A migrations

### DIFF
--- a/PersistentStoreMigrationKit/MigrationStep.swift
+++ b/PersistentStoreMigrationKit/MigrationStep.swift
@@ -11,7 +11,7 @@ import CoreData
 
 /// A `MigrationStep` instance encapsulates the migration from one `NSManagedObjectModel` to another without any intermediate models.
 /// Migration is performed via an `NSMigrationManager` using an `NSMappingModel`.
-final class MigrationStep: NSObject {
+final class MigrationStep {
     /// Specifies how to from `sourceModel` to `destinationModel`.
     let mappingModel: NSMappingModel
     /// The model to migrate from.

--- a/PersistentStoreMigrationKit/MigrationStep.swift
+++ b/PersistentStoreMigrationKit/MigrationStep.swift
@@ -9,11 +9,13 @@
 import Foundation
 import CoreData
 
-/// A `MigrationStep` instance encapsulates the migration from one `NSManagedObjectModel` to another without any intermediate models.
-/// Migration is performed via an `NSMigrationManager` using an `NSMappingModel`.
-final class MigrationStep {
+/// A migration step encapsulates the migration from one `NSManagedObjectModel` to another without any intermediate models.
+///
+/// Source and destination models can be the same (if you want to copy stores without changing the model).
+struct MigrationStep {
+    
     /// Specifies how to from `sourceModel` to `destinationModel`.
-    let mappingModel: NSMappingModel
+    let mappingModel: NSMappingModel?
     /// The model to migrate from.
     let sourceModel: NSManagedObjectModel
     /// The model to migrate to.
@@ -30,8 +32,15 @@ final class MigrationStep {
         self.destinationModel = destinationModel
         self.mappingModel = mappingModel
     }
-    
-    private var progress: Progress?
+
+    /// Initializes a migration step for single source and destination model.
+    ///
+    /// - parameters model: The model to migrate from and to.
+    init(model: NSManagedObjectModel) {
+        self.sourceModel = model
+        self.destinationModel = model
+        self.mappingModel = nil
+    }
     
     /// Performs the migration from the persistent store identified by `sourceURL` and using `sourceModel` to `destinationModel`, saving the result in the persistent store identified by `destinationURL`.
     /// 
@@ -44,8 +53,6 @@ final class MigrationStep {
     ///   - destinationStoreType: A string constant (such as `NSSQLiteStoreType`) that specifies the destination store type.
     func executeForStore(at sourceURL: URL, type sourceStoreType: String, destinationURL: URL, storeType destinationStoreType: String) throws {
         let progress = Progress(totalUnitCount: 100)
-        self.progress = progress
-        defer { self.progress = nil }
 
         let migrationManager = NSMigrationManager(sourceModel: sourceModel, destinationModel: destinationModel)
         let migrationProgressObserver = migrationManager.observe(\.migrationProgress, options: .new) { (_, change) in

--- a/PersistentStoreMigrationKitTests/MigrationPlanTests.swift
+++ b/PersistentStoreMigrationKitTests/MigrationPlanTests.swift
@@ -49,6 +49,14 @@ final class MigrationPlanTests: XCTestCase {
         super.tearDown()
     }
 
+    /// Verifies that a migration plan for A → A migrations does not required execution for store compatibility.
+    func testExecutingMigrationFromAToAIsNotRequiredForCompatibility() throws {
+        let pristineStoreInfo = testDataSet.infoForPristineStore(for: .v1, ofType: storeType)
+        let migrationPlan = try MigrationPlan(storeMetadata: pristineStoreInfo.metadata, destinationModel: TestDataSet.ModelVersion.v1.model, bundles: [.test])
+
+        XCTAssertFalse(migrationPlan.isExecutionRequiredForStoreCompatibility)
+    }
+
     /// Verifies migration plan execution for A → A migrations.
     func testMigrationFromAToAExecutesSuccessfully() throws {
         let pristineStoreInfo = testDataSet.infoForPristineStore(for: .v1, ofType: storeType)
@@ -56,7 +64,7 @@ final class MigrationPlanTests: XCTestCase {
         let migrationPlan = try MigrationPlan(storeMetadata: pristineStoreInfo.metadata, destinationModel: TestDataSet.ModelVersion.v1.model, bundles: [.test])
 
         XCTAssertNoThrow(try migrationPlan.executeForStore(at: pristineStoreInfo.url, type: storeType, destinationURL: migratedStoreURL, storeType: storeType))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: migratedStoreURL.path))
+        XCTAssertValidStore(at: migratedStoreURL, ofType: storeType, for: TestDataSet.ModelVersion.v1.model)
     }
 
     /// Verifies migration plan execution for A → B migrations.

--- a/PersistentStoreMigrationKitTests/MigrationStepTests.swift
+++ b/PersistentStoreMigrationKitTests/MigrationStepTests.swift
@@ -82,4 +82,26 @@ final class MigrationStepTests: XCTestCase {
 
         XCTAssertThrowsError(try MigrationStep.stepsForMigratingExistingStore(withMetadata: storeInfo.metadata, to: TestDataSet.ModelVersion.v4.model, searchBundles: [.test]))
     }
+
+    /// Verifies that executing a single step between models succeeds.
+    func testExecutingStepFromAToBSucceeds() throws {
+        let storeInfo = testDataSet.infoForPristineStore(for: .v1, ofType: storeType)
+        let migratedStoreURL = workingDirectoryURL.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
+        guard let mappingModel = TestDataSet.ModelVersion.mappingModel(from: .v1, to: .v2) else {
+            preconditionFailure("Required mapping model not found.")
+        }
+        let migrationStep = MigrationStep(sourceModel: TestDataSet.ModelVersion.v1.model, destinationModel: TestDataSet.ModelVersion.v2.model, mappingModel: mappingModel)
+        
+        XCTAssertNoThrow(try migrationStep.executeForStore(at: storeInfo.url, type: storeType, destinationURL: migratedStoreURL, storeType: storeType))
+    }
+
+    /// Verifies that executing a single step succeeds when the source and destination model are the same, but the source and destination URLs are different.
+    func testExecutingStepFromAToAWithDifferentSourceAndDestinationCopiesTheStore() throws {
+        let storeInfo = testDataSet.infoForPristineStore(for: .v1, ofType: storeType)
+        let migratedStoreURL = workingDirectoryURL.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
+        let migrationStep = MigrationStep(model: TestDataSet.ModelVersion.v1.model)
+
+        XCTAssertNoThrow(try migrationStep.executeForStore(at: storeInfo.url, type: storeType, destinationURL: migratedStoreURL, storeType: storeType))
+        XCTAssertValidStore(at: migratedStoreURL, ofType: storeType, for: TestDataSet.ModelVersion.v1.model)
+    }
 }

--- a/PersistentStoreMigrationKitTests/MigrationStepTests.swift
+++ b/PersistentStoreMigrationKitTests/MigrationStepTests.swift
@@ -50,12 +50,14 @@ final class MigrationStepTests: XCTestCase {
     }
 
     /// Verifies step aggregation for A → A migrations.
-    func testAToAYieldsNoSteps() throws {
+    func testAToAYieldsOneOptionalStep() throws {
         let storeInfo = testDataSet.infoForPristineStore(for: .v1, ofType: storeType)
 
         let steps = try MigrationStep.stepsForMigratingExistingStore(withMetadata: storeInfo.metadata, to: TestDataSet.ModelVersion.v1.model, searchBundles: [.test])
 
-        XCTAssertTrue(steps.isEmpty)
+        XCTAssertEqual(steps.count, 1)
+        guard let firstStep = steps.first else { return }
+        XCTAssertTrue(firstStep.isSameSourceAndDestinationModel)
     }
 
     /// Verifies step aggregation for A → B migrations.

--- a/PersistentStoreMigrationKitTests/TestDataSet.swift
+++ b/PersistentStoreMigrationKitTests/TestDataSet.swift
@@ -116,6 +116,10 @@ extension TestDataSet {
 
             return Array(allVersions.suffix(from: earlierIndex + 1))
         }
+
+        static func mappingModel(from earlierVersion: ModelVersion, to laterVersion: ModelVersion) -> NSMappingModel? {
+            return NSMappingModel(from: [.test], forSourceModel: earlierVersion.model, destinationModel: laterVersion.model)
+        }
     }
 }
 


### PR DESCRIPTION
Makes A → A migrations consistent with A → _X_ migrations, i.e. always creates a copy of the store, even if the store source and destination models are the same.

Because of this there are no empty migration plans anymore. Every plan will have at least one step, even if that step effectively makes an identical copy of the source. If you want to avoid performing unnecessary work in such a case, check the migration plan’s `isExecutionRequiredForStoreCompatibility` property. If this is `false` you can skip executing the migration plan.

Closes #11.